### PR TITLE
Fix inadvertent wrapping on hyphens on mobile

### DIFF
--- a/steno_anki/anki.py
+++ b/steno_anki/anki.py
@@ -42,6 +42,7 @@ class Anki:
     font-family: "Stenodisplay-ClassicLarge";
     font-size: 168px;
     color: #008080;
+    white-space: nowrap;
 }
 .typeGood,
 .nightMode .typeGood,


### PR DESCRIPTION
Css to prevent outlines with disambiguating hyphens from wrapping and placing the right hand letters on the left side as a second stroke.